### PR TITLE
Changed DPT internal instructions to return use DistanceValue

### DIFF
--- a/test/formats/dpt_tests.cpp
+++ b/test/formats/dpt_tests.cpp
@@ -66,11 +66,11 @@ TEST_P(Suite, extracts_correct_values) {
 
   ASSERT_NE(meters, nullptr);
   EXPECT_THAT(
-      meters->as<wellnmea::instructions::NumberValue>()->getValue().value(),
+      meters->as<wellnmea::instructions::DistanceValue>()->raw().value(),
       ::testing::DoubleNear(param["depth"], 0.01));
   ASSERT_NE(offset, nullptr);
   EXPECT_THAT(
-      offset->as<wellnmea::instructions::NumberValue>()->getValue().value(),
+      offset->as<wellnmea::instructions::DistanceValue>()->raw().value(),
       ::testing::DoubleNear(param["offset"], 0.01));
 }
 

--- a/test/instructions/distance_instruction_test.cpp
+++ b/test/instructions/distance_instruction_test.cpp
@@ -90,7 +90,8 @@ TEST_F(Suite, returns_correct_value_for_feets) {
   ASSERT_NE(value, nullptr);
   EXPECT_THAT(value->raw().value(), ::testing::DoubleNear(56.0, 0.01));
   EXPECT_THAT(value->units().value(), ::testing::Eq('f'));
-  EXPECT_THAT(value->converted().value(), ::testing::DoubleNear(56.0 * 0.3048, 0.0001));
+  EXPECT_THAT(value->converted().value(),
+              ::testing::DoubleNear(56.0 * 0.3048, 0.0001));
 }
 
 TEST_F(Suite, returns_correct_value_for_meters) {
@@ -128,5 +129,28 @@ TEST_F(Suite, returns_correct_value_for_fathoms) {
   ASSERT_NE(value, nullptr);
   EXPECT_THAT(value->raw().value(), ::testing::DoubleNear(56.0, 0.01));
   EXPECT_THAT(value->units().value(), ::testing::Eq('F'));
-  EXPECT_THAT(value->converted().value(), ::testing::DoubleNear(56.0 * 1.8288, 0.00001));
+  EXPECT_THAT(value->converted().value(),
+              ::testing::DoubleNear(56.0 * 1.8288, 0.00001));
+}
+
+TEST_F(Suite, works_with_predefined_units) {
+  wellnmea::Sentence sentence;
+
+  sentence.fields.push_back("3.6");
+
+  auto it = sentence.fields.begin();
+  auto end = sentence.fields.end();
+
+  delete instr;
+  instr = new wellnmea::instructions::DistanceInstruction("predef", 'M');
+
+  auto value =
+      instr->extract(it, end)->as<wellnmea::instructions::DistanceValue>();
+
+  ASSERT_NE(value, nullptr);
+  ASSERT_TRUE(*value);
+  EXPECT_THAT(value->raw().value(), ::testing::DoubleNear(3.6, 0.01));
+  EXPECT_THAT(value->units().value(), ::testing::Eq('M'));
+
+  EXPECT_THAT(value->converted().value(), ::testing::DoubleNear(3.6, 0.01));
 }

--- a/wellnmea/formats/dpt.hpp
+++ b/wellnmea/formats/dpt.hpp
@@ -2,17 +2,28 @@
 
 #include <wellnmea/formats/format.hpp>
 
-#include <wellnmea/instructions/number_instruction.hpp>
+#include <wellnmea/instructions/distance_instruction.hpp>
 
 namespace wa {
 using namespace wellnmea::instructions;
 }  // namespace wa
-
+/**
+ * @brief NMEA **DPT message parsing format** - Depth of Water
+ *  
+ * Example:
+ * $INDPT,2.3,0.0*46 
+ *         ^   ^
+ *         1   2
+ * 1  - Depth relative to transducer, meters
+ * 2  - Offset from transducer, meters
+ *      Positive means distance from transducer to water line
+ *      Negative means distance from transducer to keel
+ */
 class DPT : public wellnmea::formats::Format {
  public:
   DPT()
       : Format({
-            new wa::NumberInstruction("depth"),
-            new wa::NumberInstruction("offset"),
+            new wa::DistanceInstruction("depth", 'M'),
+            new wa::DistanceInstruction("offset", 'M'),
         }) {}
 };


### PR DESCRIPTION
- [x] `DistanceInstruction` now has predefined units
- [x]  `DPT` format now uses `DistanceInstruction` under the hood